### PR TITLE
Portability and type improvements for unix socket handling

### DIFF
--- a/command_linux.go
+++ b/command_linux.go
@@ -1,0 +1,21 @@
+package runc
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+)
+
+func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
+	command := r.Command
+	if command == "" {
+		command = DefaultCommand
+	}
+	cmd := exec.CommandContext(context, command, append(r.args(), args...)...)
+	if r.PdeathSignal != 0 {
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Pdeathsig: r.PdeathSignal,
+		}
+	}
+	return cmd
+}

--- a/command_other.go
+++ b/command_other.go
@@ -1,0 +1,16 @@
+// +build !linux
+
+package runc
+
+import (
+	"context"
+	"os/exec"
+)
+
+func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
+	command := r.Command
+	if command == "" {
+		command = DefaultCommand
+	}
+	return exec.CommandContext(context, command, append(r.args(), args...)...)
+}

--- a/console.go
+++ b/console.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/console"
-	"github.com/opencontainers/runc/libcontainer/utils"
+	"golang.org/x/sys/unix"
 )
 
 // NewConsoleSocket creates a new unix socket at the provided path to accept a
@@ -64,6 +64,50 @@ func (c *Socket) Path() string {
 	return c.path
 }
 
+// recvFd waits for a file descriptor to be sent over the given AF_UNIX
+// socket. The file name of the remote file descriptor will be recreated
+// locally (it is sent as non-auxiliary data in the same payload).
+func recvFd(socket *net.UnixConn) (*os.File, error) {
+	const MaxNameLen = 4096
+	var oobSpace = unix.CmsgSpace(4)
+
+	name := make([]byte, MaxNameLen)
+	oob := make([]byte, oobSpace)
+
+	n, oobn, _, _, err := socket.ReadMsgUnix(name, oob)
+	if err != nil {
+		return nil, err
+	}
+
+	if n >= MaxNameLen || oobn != oobSpace {
+		return nil, fmt.Errorf("recvfd: incorrect number of bytes read (n=%d oobn=%d)", n, oobn)
+	}
+
+	// Truncate.
+	name = name[:n]
+	oob = oob[:oobn]
+
+	scms, err := unix.ParseSocketControlMessage(oob)
+	if err != nil {
+		return nil, err
+	}
+	if len(scms) != 1 {
+		return nil, fmt.Errorf("recvfd: number of SCMs is not 1: %d", len(scms))
+	}
+	scm := scms[0]
+
+	fds, err := unix.ParseUnixRights(&scm)
+	if err != nil {
+		return nil, err
+	}
+	if len(fds) != 1 {
+		return nil, fmt.Errorf("recvfd: number of fds is not 1: %d", len(fds))
+	}
+	fd := uintptr(fds[0])
+
+	return os.NewFile(fd, string(name)), nil
+}
+
 // ReceiveMaster blocks until the socket receives the pty master
 func (c *Socket) ReceiveMaster() (console.Console, error) {
 	conn, err := c.l.Accept()
@@ -71,15 +115,11 @@ func (c *Socket) ReceiveMaster() (console.Console, error) {
 		return nil, err
 	}
 	defer conn.Close()
-	unix, ok := conn.(*net.UnixConn)
+	uc, ok := conn.(*net.UnixConn)
 	if !ok {
 		return nil, fmt.Errorf("received connection which was not a unix socket")
 	}
-	sock, err := unix.File()
-	if err != nil {
-		return nil, err
-	}
-	f, err := utils.RecvFd(sock)
+	f, err := recvFd(uc)
 	if err != nil {
 		return nil, err
 	}

--- a/console_test.go
+++ b/console_test.go
@@ -11,6 +11,9 @@ func TestTempConsole(t *testing.T) {
 		t.Fatal(err)
 	}
 	path := c.Path()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	}
 	if err := c.Close(); err != nil {
 		t.Fatal(err)
 	}

--- a/runc.go
+++ b/runc.go
@@ -523,20 +523,6 @@ func (r *Runc) args() (out []string) {
 	return out
 }
 
-func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
-	command := r.Command
-	if command == "" {
-		command = DefaultCommand
-	}
-	cmd := exec.CommandContext(context, command, append(r.args(), args...)...)
-	if r.PdeathSignal != 0 {
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Pdeathsig: r.PdeathSignal,
-		}
-	}
-	return cmd
-}
-
 // runOrError will run the provided command.  If an error is
 // encountered and neither Stdout or Stderr was set the error and the
 // stderr of the command will be returned in the format of <error>:


### PR DESCRIPTION
- Pdeathsig only exists on Linux; make this conditional
- add our own `recvFd` implementation, as the `runc` one is included in `github.com/opencontainers/runc/libcontainer/utils` which is Linux specific; this implementation is a little cleanup up to use Go unix socket specific functions rather than the syscalls from `s/sys/unix` where possible. This removes a whole chunk of `runc` dependencies from `containerd`
- while in the cleaning up unix socket mood, clean up `net.Listener` to be the more specific `net.UnixListener`; this means we do not have to store `path` as it is available as the local address of a listener.

With these changes and some more fixes in `containerd` I have `containerd-shim` compiling on Darwin.

Tested with `containerd` master.