### PR TITLE
No reason to require cgo build

### DIFF
--- a/console.go
+++ b/console.go
@@ -1,5 +1,3 @@
-// +build cgo
-
 package runc
 
 import (


### PR DESCRIPTION
This just uses unix sockets, does not require cgo

Signed-off-by: Justin Cormack <justin.cormack@docker.com>

I can't see any reason why this is needed... this helps cross compile support which doesn't work with cgo see https://github.com/containerd/containerd/issues/866