### PR TITLE
Add option for runc to unshare process group

### DIFF
--- a/command_linux.go
+++ b/command_linux.go
@@ -12,10 +12,12 @@ func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
 		command = DefaultCommand
 	}
 	cmd := exec.CommandContext(context, command, append(r.args(), args...)...)
-	if r.PdeathSignal != 0 {
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			Pdeathsig: r.PdeathSignal,
-		}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: r.Setpgid,
 	}
+	if r.PdeathSignal != 0 {
+		cmd.SysProcAttr.Pdeathsig = r.PdeathSignal
+	}
+
 	return cmd
 }

--- a/runc.go
+++ b/runc.go
@@ -39,6 +39,7 @@ type Runc struct {
 	Log           string
 	LogFormat     Format
 	PdeathSignal  syscall.Signal
+	Setpgid       bool
 	Criu          string
 	SystemdCgroup string
 }


### PR DESCRIPTION
Running runc in same process group has some surprising side-effects when library functions are being used, for example when signals are being sent to the process group by a shell. I made it opt-in atm but could set it to default as well.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>