### PR TITLE
Kill exec command with SIGTERM

### DIFF
--- a/runc_test.go
+++ b/runc_test.go
@@ -1,6 +1,15 @@
 package runc
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
 
 func TestParseVersion(t *testing.T) {
 	const data = `runc version 1.0.0-rc3
@@ -21,4 +30,44 @@ spec: 1.0.0-rc5-dev`
 		t.Errorf("expected spec version 1.0.0-rc5-dev but received %s", v.Spec)
 	}
 
+}
+
+func TestExecCancel(t *testing.T) {
+	r := Runc{}
+
+	r.Command = "docker-runc"
+
+	containers, err := r.List(context.Background())
+	if err != nil || len(containers) == 0 {
+		t.Skip("No running container found", err)
+	}
+
+	c := containers[0]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	result := make(chan error, 1)
+
+	go func() {
+		result <- r.Exec(ctx, c.ID, specs.Process{
+			Cwd:  "/",
+			Args: []string{"/bin/sleep", "10"},
+		}, &ExecOpts{})
+	}()
+
+	time.AfterFunc(3*time.Second, cancel)
+
+	err = <-result
+
+	if err == nil {
+		t.Error("Expect error")
+	}
+
+	if !strings.HasPrefix(
+		err.Error(),
+		fmt.Sprintf("exec failed with exit code %d", 128+syscall.SIGTERM),
+	) {
+		t.Error("Wrong return code")
+	}
 }


### PR DESCRIPTION
fix #21 

I try to change as little as possible, so I only changed how command is handled in `runc.Exec`.

I also added a simple test which needs a running container on the machine to test the return code. It needs further improvement