### PR TITLE
Add NewNullIO for efficient empty IO handling

### DIFF
--- a/io.go
+++ b/io.go
@@ -163,3 +163,47 @@ func (s *stdio) Stdout() io.ReadCloser {
 func (s *stdio) Stderr() io.ReadCloser {
 	return os.Stderr
 }
+
+// NewNullIO returns IO setup for /dev/null use with runc
+func NewNullIO() (IO, error) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		return nil, err
+	}
+	return &nullIO{
+		devNull: f,
+	}, nil
+}
+
+type nullIO struct {
+	devNull *os.File
+}
+
+func (n *nullIO) Close() error {
+	// this should be closed after start but if not
+	// make sure we close the file but don't return the error
+	n.devNull.Close()
+	return nil
+}
+
+func (n *nullIO) Stdin() io.WriteCloser {
+	return nil
+}
+
+func (n *nullIO) Stdout() io.ReadCloser {
+	return nil
+}
+
+func (n *nullIO) Stderr() io.ReadCloser {
+	return nil
+}
+
+func (n *nullIO) Set(c *exec.Cmd) {
+	// don't set STDIN here
+	c.Stdout = n.devNull
+	c.Stderr = n.devNull
+}
+
+func (n *nullIO) CloseAfterStart() error {
+	return n.devNull.Close()
+}


### PR DESCRIPTION
This gives /dev/null directly to the container's process.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>