### PR TITLE
handle runc command context manually

### DIFF
--- a/command_linux.go
+++ b/command_linux.go
@@ -1,17 +1,16 @@
 package runc
 
 import (
-	"context"
 	"os/exec"
 	"syscall"
 )
 
-func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
+func (r *Runc) command(args ...string) *exec.Cmd {
 	command := r.Command
 	if command == "" {
 		command = DefaultCommand
 	}
-	cmd := exec.CommandContext(context, command, append(r.args(), args...)...)
+	cmd := exec.Command(command, append(r.args(), args...)...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: r.Setpgid,
 	}

--- a/command_other.go
+++ b/command_other.go
@@ -3,14 +3,13 @@
 package runc
 
 import (
-	"context"
 	"os/exec"
 )
 
-func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
+func (r *Runc) command(args ...string) *exec.Cmd {
 	command := r.Command
 	if command == "" {
 		command = DefaultCommand
 	}
-	return exec.CommandContext(context, command, append(r.args(), args...)...)
+	return exec.Command(command, append(r.args(), args...)...)
 }

--- a/monitor.go
+++ b/monitor.go
@@ -1,17 +1,22 @@
 package runc
 
 import (
+	"context"
+	"os"
 	"os/exec"
 	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
-var Monitor ProcessMonitor = &defaultMonitor{}
+var Monitor ProcessMonitor = DefaultMonitor(unix.SIGTERM, 10*time.Second)
 
 type Exit struct {
 	Timestamp time.Time
 	Pid       int
 	Status    int
+	Signal    os.Signal
 }
 
 // ProcessMonitor is an interface for process monitoring
@@ -22,25 +27,55 @@ type Exit struct {
 // These methods should match the methods exposed by exec.Cmd to provide
 // a consistent experience for the caller
 type ProcessMonitor interface {
-	Start(*exec.Cmd) (chan Exit, error)
+	Start(context.Context, *exec.Cmd) (chan Exit, error)
 	Wait(*exec.Cmd, chan Exit) (int, error)
 }
 
-type defaultMonitor struct {
+func DefaultMonitor(defaultSignal os.Signal, killTimeout time.Duration) ProcessMonitor {
+	return &defaultMonitor{
+		defaultSignal: defaultSignal,
+		killTimeout:   killTimeout,
+	}
 }
 
-func (m *defaultMonitor) Start(c *exec.Cmd) (chan Exit, error) {
+type defaultMonitor struct {
+	defaultSignal os.Signal
+	killTimeout   time.Duration
+}
+
+func (m *defaultMonitor) Start(ctx context.Context, c *exec.Cmd) (chan Exit, error) {
 	if err := c.Start(); err != nil {
 		return nil, err
 	}
 	ec := make(chan Exit, 1)
+	waitDone := make(chan struct{}, 1)
+	go func() {
+		select {
+		case <-ctx.Done():
+			if m.defaultSignal == nil {
+				c.Process.Signal(unix.SIGKILL)
+			} else {
+				c.Process.Signal(m.defaultSignal)
+				if m.killTimeout > 0 {
+					select {
+					case <-time.After(m.killTimeout):
+						c.Process.Kill()
+					case <-waitDone:
+					}
+				}
+			}
+		case <-waitDone:
+		}
+	}()
 	go func() {
 		var status int
+		var signal os.Signal
 		if err := c.Wait(); err != nil {
 			status = 255
 			if exitErr, ok := err.(*exec.ExitError); ok {
 				if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
 					status = ws.ExitStatus()
+					signal = ws.Signal()
 				}
 			}
 		}
@@ -48,8 +83,10 @@ func (m *defaultMonitor) Start(c *exec.Cmd) (chan Exit, error) {
 			Timestamp: time.Now(),
 			Pid:       c.Process.Pid,
 			Status:    status,
+			Signal:    signal,
 		}
 		close(ec)
+		close(waitDone)
 	}()
 	return ec, nil
 }

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -1,0 +1,40 @@
+package runc
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestMonitorCustomSignal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.Command("sleep", "10")
+	monitor := DefaultMonitor(unix.SIGTERM, time.Second)
+	ec, err := monitor.Start(ctx, cmd)
+	if err != nil {
+		t.Errorf("Failed to start command: %v", err)
+	}
+	e := <-ec
+	if e.Signal != unix.SIGTERM {
+		t.Errorf("Got signal (%v), expected (%v)", e.Signal, unix.SIGTERM)
+	}
+}
+
+func TestMonitorKill(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cmd := exec.Command("sleep", "10")
+	monitor := &defaultMonitor{}
+	ec, err := monitor.Start(ctx, cmd)
+	if err != nil {
+		t.Errorf("Failed to start command: %v", err)
+	}
+	e := <-ec
+	if e.Signal != unix.SIGKILL {
+		t.Errorf("Got signal (%v), expected (%v)", e.Signal, unix.SIGTERM)
+	}
+}


### PR DESCRIPTION
instead of defering to Go's stdlib to handle context, which only sends
SIGKILL when the context timed out, handle the context timeout ourselves
so we can inject a custom signal first ( default to SIGTERM, and send
SIGKILL after 10 seconds) to stop container more gracefully.

Fix #21 
Replace #22