### PR TITLE
Use user-specific temp directory if set

### DIFF
--- a/console.go
+++ b/console.go
@@ -50,7 +50,8 @@ func NewConsoleSocket(path string) (*Socket, error) {
 // NewTempConsoleSocket returns a temp console socket for use with a container
 // On Close(), the socket is deleted
 func NewTempConsoleSocket() (*Socket, error) {
-	dir, err := ioutil.TempDir("", "pty")
+	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
+	dir, err := ioutil.TempDir(runtimeDir, "pty")
 	if err != nil {
 		return nil, err
 	}
@@ -65,6 +66,11 @@ func NewTempConsoleSocket() (*Socket, error) {
 	l, err := net.ListenUnix("unix", addr)
 	if err != nil {
 		return nil, err
+	}
+	if runtimeDir != "" {
+		if err := os.Chmod(abs, 0755|os.ModeSticky); err != nil {
+			return nil, err
+		}
 	}
 	return &Socket{
 		l:     l,

--- a/runc.go
+++ b/runc.go
@@ -208,7 +208,7 @@ func (o *ExecOpts) args() (out []string, err error) {
 // Exec executres and additional process inside the container based on a full
 // OCI Process specification
 func (r *Runc) Exec(context context.Context, id string, spec specs.Process, opts *ExecOpts) error {
-	f, err := ioutil.TempFile("", "runc-process")
+	f, err := ioutil.TempFile(os.Getenv("XDG_RUNTIME_DIR"), "runc-process")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This allows non-privileged users to use containerd. This is part of a
larger track of work integrating containerd into Cloudfoundry's garden
with support for rootless.

This is linked to https://github.com/containerd/containerd/pull/2325

[#156343575]

Signed-off-by: Claudia Beresford <cberesford@pivotal.io>