### PR TITLE
Expose parsePSOutput.

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -411,7 +411,7 @@ func (r *Runc) Top(context context.Context, id string, psOptions string) (*TopRe
 		return nil, fmt.Errorf("%s: %s", err, data)
 	}
 
-	topResults, err := parsePSOutput(data)
+	topResults, err := ParsePSOutput(data)
 	if err != nil {
 		return nil, fmt.Errorf("%s: ", err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -73,8 +73,8 @@ func fieldsASCII(s string) []string {
 	return strings.FieldsFunc(s, fn)
 }
 
-// parsePSOutput parses the runtime's ps raw output and returns a TopResults
-func parsePSOutput(output []byte) (*TopResults, error) {
+// ParsePSOutput parses the runtime's ps raw output and returns a TopResults
+func ParsePSOutput(output []byte) (*TopResults, error) {
 	topResults := &TopResults{}
 
 	lines := strings.Split(string(output), "\n")


### PR DESCRIPTION
This is very useful when implementing go library for other runc like CLIs.

Signed-off-by: Lantao Liu <lantaol@google.com>