### PR TITLE
add support for --rootless

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -66,6 +66,7 @@ type Runc struct {
 	Setpgid       bool
 	Criu          string
 	SystemdCgroup bool
+	Rootless      *bool // nil stands for "auto"
 }
 
 // List returns all containers created inside the provided runc root directory
@@ -654,6 +655,10 @@ func (r *Runc) args() (out []string) {
 	}
 	if r.SystemdCgroup {
 		out = append(out, "--systemd-cgroup")
+	}
+	if r.Rootless != nil {
+		// nil stands for "auto" (differs from explicit "false")
+		out = append(out, "--rootless="+strconv.FormatBool(*r.Rootless))
 	}
 	return out
 }


### PR DESCRIPTION
The --rootless flag was introduced in opencontainers/runc#1688.

In most cases runc itself can detect the appropriate value,
but it is considered to be there are some corner cases.

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

@cyphar @giuseppe @brauner (ref: https://github.com/opencontainers/runc/pull/1833)