### PR TITLE
Break apart NewPipeIO to windows/unix

### DIFF
--- a/console.go
+++ b/console.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 /*
    Copyright The containerd Authors.
 

--- a/io.go
+++ b/io.go
@@ -20,9 +20,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-
-	"github.com/pkg/errors"
-	"golang.org/x/sys/unix"
 )
 
 type IO interface {
@@ -35,51 +32,6 @@ type IO interface {
 
 type StartCloser interface {
 	CloseAfterStart() error
-}
-
-// NewPipeIO creates pipe pairs to be used with runc
-func NewPipeIO(uid, gid int) (i IO, err error) {
-	var pipes []*pipe
-	// cleanup in case of an error
-	defer func() {
-		if err != nil {
-			for _, p := range pipes {
-				p.Close()
-			}
-		}
-	}()
-	stdin, err := newPipe()
-	if err != nil {
-		return nil, err
-	}
-	pipes = append(pipes, stdin)
-	if err = unix.Fchown(int(stdin.r.Fd()), uid, gid); err != nil {
-		return nil, errors.Wrap(err, "failed to chown stdin")
-	}
-
-	stdout, err := newPipe()
-	if err != nil {
-		return nil, err
-	}
-	pipes = append(pipes, stdout)
-	if err = unix.Fchown(int(stdout.w.Fd()), uid, gid); err != nil {
-		return nil, errors.Wrap(err, "failed to chown stdout")
-	}
-
-	stderr, err := newPipe()
-	if err != nil {
-		return nil, err
-	}
-	pipes = append(pipes, stderr)
-	if err = unix.Fchown(int(stderr.w.Fd()), uid, gid); err != nil {
-		return nil, errors.Wrap(err, "failed to chown stderr")
-	}
-
-	return &pipeIO{
-		in:  stdin,
-		out: stdout,
-		err: stderr,
-	}, nil
 }
 
 func newPipe() (*pipe, error) {

--- a/io_unix.go
+++ b/io_unix.go
@@ -1,0 +1,69 @@
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+)
+
+// NewPipeIO creates pipe pairs to be used with runc
+func NewPipeIO(uid, gid int) (i IO, err error) {
+	var pipes []*pipe
+	// cleanup in case of an error
+	defer func() {
+		if err != nil {
+			for _, p := range pipes {
+				p.Close()
+			}
+		}
+	}()
+	stdin, err := newPipe()
+	if err != nil {
+		return nil, err
+	}
+	pipes = append(pipes, stdin)
+	if err = unix.Fchown(int(stdin.r.Fd()), uid, gid); err != nil {
+		return nil, errors.Wrap(err, "failed to chown stdin")
+	}
+
+	stdout, err := newPipe()
+	if err != nil {
+		return nil, err
+	}
+	pipes = append(pipes, stdout)
+	if err = unix.Fchown(int(stdout.w.Fd()), uid, gid); err != nil {
+		return nil, errors.Wrap(err, "failed to chown stdout")
+	}
+
+	stderr, err := newPipe()
+	if err != nil {
+		return nil, err
+	}
+	pipes = append(pipes, stderr)
+	if err = unix.Fchown(int(stderr.w.Fd()), uid, gid); err != nil {
+		return nil, errors.Wrap(err, "failed to chown stderr")
+	}
+
+	return &pipeIO{
+		in:  stdin,
+		out: stdout,
+		err: stderr,
+	}, nil
+}

--- a/io_windows.go
+++ b/io_windows.go
@@ -1,0 +1,55 @@
+// +build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+// NewPipeIO creates pipe pairs to be used with runc
+func NewPipeIO() (i IO, err error) {
+	var pipes []*pipe
+	// cleanup in case of an error
+	defer func() {
+		if err != nil {
+			for _, p := range pipes {
+				p.Close()
+			}
+		}
+	}()
+	stdin, err := newPipe()
+	if err != nil {
+		return nil, err
+	}
+	pipes = append(pipes, stdin)
+
+	stdout, err := newPipe()
+	if err != nil {
+		return nil, err
+	}
+	pipes = append(pipes, stdout)
+
+	stderr, err := newPipe()
+	if err != nil {
+		return nil, err
+	}
+	pipes = append(pipes, stderr)
+
+	return &pipeIO{
+		in:  stdin,
+		out: stdout,
+		err: stderr,
+	}, nil
+}


### PR DESCRIPTION
Moves NewPipeIO to GOOS specific to avoid setting the unix.Fchown flags
that dont apply on windows.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>