### PR TITLE
Reorder pipe close to be write/read

### DIFF
--- a/io.go
+++ b/io.go
@@ -51,9 +51,9 @@ type pipe struct {
 }
 
 func (p *pipe) Close() error {
-	err := p.r.Close()
-	if werr := p.w.Close(); err == nil {
-		err = werr
+	err := p.w.Close()
+	if rerr := p.r.Close(); err == nil {
+		err = rerr
 	}
 	return err
 }


### PR DESCRIPTION
Reorder's pipe close to avoid locking issues. By closing write then read
if there is an outstanding relay that could be holding a lock the write
end of the pipe forwards the EOF close to the read side freeing any
relay's.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>