### PR TITLE
Allow empty version results

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -608,9 +608,8 @@ func parseVersion(data []byte) (Version, error) {
 	var v Version
 	parts := strings.Split(strings.TrimSpace(string(data)), "\n")
 	if len(parts) != 3 {
-		return v, ErrParseRuncVersion
+		return v, nil
 	}
-
 	for i, p := range []struct {
 		dest  *string
 		split string

--- a/runc_test.go
+++ b/runc_test.go
@@ -36,5 +36,4 @@ spec: 1.0.0-rc5-dev`
 	if v.Spec != "1.0.0-rc5-dev" {
 		t.Errorf("expected spec version 1.0.0-rc5-dev but received %s", v.Spec)
 	}
-
 }


### PR DESCRIPTION
Because multiple ppl compile runc, we cannot ensure that the version and
commit are in the binary when people do not use the make file.  Allow
empty versions to be returned as long as the call to `runc --version` is
successful.

Closes #47

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>