### PR TITLE
Add common project content/checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,20 @@
 language: go
 go:
     - 1.7.x
+    - tip
+
+install:
+  - go get -t ./...
+  - go get -u github.com/vbatts/git-validation
+  - go get -u github.com/kunalkushwaha/ltag
+
+before_script:
+  - pushd ..; git clone https://github.com/containerd/project; popd
+
+script:
+  - DCO_VERBOSITY=-q ../project/script/validate/dco
+  - ../project/script/validate/fileheader ../project/
+  - go test -v -race -covermode=atomic -coverprofile=coverage.txt ./...
+
+after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # go-runc
 
 [![Build Status](https://travis-ci.org/containerd/go-runc.svg?branch=master)](https://travis-ci.org/containerd/go-runc)
-
+[![codecov](https://codecov.io/gh/containerd/go-runc/branch/master/graph/badge.svg)](https://codecov.io/gh/containerd/go-runc)
 
 This is a package for consuming the [runc](https://github.com/opencontainers/runc) binary in your Go applications.
 It tries to expose all the settings and features of the runc CLI.  If there is something missing then add it, its opensource!
@@ -12,3 +12,14 @@ or greater.
 ## Docs
 
 Docs can be found at [godoc.org](https://godoc.org/github.com/containerd/go-runc).
+
+## Project details
+
+The go-runc is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.

--- a/console_test.go
+++ b/console_test.go
@@ -23,6 +23,10 @@ import (
 )
 
 func TestTempConsole(t *testing.T) {
+	if err := os.Setenv("XDG_RUNTIME_DIR", ""); err != nil {
+		t.Fatalf("failed to clear the XDG_RUNTIME_DIR env: %v", err)
+	}
+
 	c, path := testSocketWithCorrectStickyBitMode(t, 0)
 	ensureSocketCleanup(t, c, path)
 }


### PR DESCRIPTION
In order to make sure that there is no flaky case, clear the
`XDG_RUNTIME_DIR` env before test the `TestTempConsole`.

Signed-off-by: Wei Fu <fuweid89@gmail.com>