### PR TITLE
Fix Method of judging command execution failure

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -275,7 +275,11 @@ func (r *Runc) Run(context context.Context, id, bundle string, opts *CreateOpts)
 	if err != nil {
 		return -1, err
 	}
-	return Monitor.Wait(cmd, ec)
+	status, err := Monitor.Wait(cmd, ec)
+	if err == nil && status != 0 {
+		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+	}
+	return status, err
 }
 
 type DeleteOpts struct {
@@ -570,7 +574,11 @@ func (r *Runc) Restore(context context.Context, id, bundle string, opts *Restore
 			}
 		}
 	}
-	return Monitor.Wait(cmd, ec)
+	status, err := Monitor.Wait(cmd, ec)
+	if err == nil && status != 0 {
+		err = fmt.Errorf("%s did not terminate sucessfully", cmd.Args[0])
+	}
+	return status, err
 }
 
 // Update updates the current container with the provided resource spec


### PR DESCRIPTION
should judge restore and run command execution failure depend both on error and
status Monitor.Wait() return.
Since Monitor.Wait() always return nil as long as command execute.

Signed-off-by: Ace-Tang <aceapril@126.com>

I only test it with pouch,  before the patch
```
failed to retrieve OCI runtime container pid: open /home/t4/pouch/containerd/state/io.containerd.runtime.v1.linux/default/3f9dbd58131ca9d9151a0220e1d8ca833c26f750bf055124fc38f09d4de27a06/init.pid: no such file or directory: unknown
```

and with this patch in containerd, it can get correct error log
```
OCI runtime restore failed: criu failed: type NOTIFY errno 0\nlog file: /tmp/testcr/cp3/restore.log: unknown
```