### PR TITLE
Change the type of PdeathSignal

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -29,10 +29,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 )
 
 // Format is the type of log formatting options avaliable
@@ -63,7 +63,7 @@ type Runc struct {
 	Debug         bool
 	Log           string
 	LogFormat     Format
-	PdeathSignal  syscall.Signal
+	PdeathSignal  unix.Signal
 	Setpgid       bool
 	Criu          string
 	SystemdCgroup bool


### PR DESCRIPTION
As related to https://github.com/containerd/containerd/pull/4317, this commit changes the definition of PdeathSignal to use x/sys.

Signed-off-by: Kenta Tada <Kenta.Tada@sony.com>