### PR TITLE
darwin: ignore fchown failure on darwin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e
 	github.com/opencontainers/runtime-spec v1.0.1
 	github.com/pkg/errors v0.8.1
+	github.com/sirupsen/logrus v1.6.0
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,16 @@
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e h1:GdiIYd8ZDOrT++e1NjhSD4rGt9zaJukHm4rt5F4mRQc=
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/opencontainers/runtime-spec v1.0.1 h1:wY4pOY8fBdSIvs9+IDHC55thBuEulhzfSgKeC1yFvzQ=
 github.com/opencontainers/runtime-spec v1.0.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
+github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/io_unix.go
+++ b/io_unix.go
@@ -20,7 +20,9 @@ package runc
 
 import (
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
+	"runtime"
 )
 
 // NewPipeIO creates pipe pairs to be used with runc
@@ -47,7 +49,13 @@ func NewPipeIO(uid, gid int, opts ...IOOpt) (i IO, err error) {
 		}
 		pipes = append(pipes, stdin)
 		if err = unix.Fchown(int(stdin.r.Fd()), uid, gid); err != nil {
-			return nil, errors.Wrap(err, "failed to chown stdin")
+			// TODO: revert with proper darwin solution, skipping for now
+			// as darwin chown is returning EINVAL on anonymous pipe
+			if runtime.GOOS == "darwin" {
+				logrus.WithError(err).Debug("failed to chown stdin, ignored")
+			} else {
+				return nil, errors.Wrap(err, "failed to chown stdin")
+			}
 		}
 	}
 	if option.OpenStdout {
@@ -56,7 +64,13 @@ func NewPipeIO(uid, gid int, opts ...IOOpt) (i IO, err error) {
 		}
 		pipes = append(pipes, stdout)
 		if err = unix.Fchown(int(stdout.w.Fd()), uid, gid); err != nil {
-			return nil, errors.Wrap(err, "failed to chown stdout")
+			// TODO: revert with proper darwin solution, skipping for now
+			// as darwin chown is returning EINVAL on anonymous pipe
+			if runtime.GOOS == "darwin" {
+				logrus.WithError(err).Debug("failed to chown stdout, ignored")
+			} else {
+				return nil, errors.Wrap(err, "failed to chown stdout")
+			}
 		}
 	}
 	if option.OpenStderr {
@@ -65,7 +79,13 @@ func NewPipeIO(uid, gid int, opts ...IOOpt) (i IO, err error) {
 		}
 		pipes = append(pipes, stderr)
 		if err = unix.Fchown(int(stderr.w.Fd()), uid, gid); err != nil {
-			return nil, errors.Wrap(err, "failed to chown stderr")
+			// TODO: revert with proper darwin solution, skipping for now
+			// as darwin chown is returning EINVAL on anonymous pipe
+			if runtime.GOOS == "darwin" {
+				logrus.WithError(err).Debug("failed to chown stderr, ignored")
+			} else {
+				return nil, errors.Wrap(err, "failed to chown stderr")
+			}
 		}
 	}
 	return &pipeIO{


### PR DESCRIPTION
fchown(2) on darwin returns EINVAL on anonymous pipe, thus this commit
ignores this checks.

This is related to the PR of containerd (https://github.com/containerd/containerd/pull/4526).