### PR TITLE
Fix a regression of windows build issue of undefined symbol

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/sys/unix"
 )
 
 // Format is the type of log formatting options avaliable
@@ -54,21 +53,6 @@ const (
 	// DefaultCommand is the default command for Runc
 	DefaultCommand = "runc"
 )
-
-// Runc is the client to the runc cli
-type Runc struct {
-	//If command is empty, DefaultCommand is used
-	Command       string
-	Root          string
-	Debug         bool
-	Log           string
-	LogFormat     Format
-	PdeathSignal  unix.Signal
-	Setpgid       bool
-	Criu          string
-	SystemdCgroup bool
-	Rootless      *bool // nil stands for "auto"
-}
 
 // List returns all containers created inside the provided runc root directory
 func (r *Runc) List(context context.Context) ([]*Container, error) {

--- a/runc_unix.go
+++ b/runc_unix.go
@@ -1,0 +1,38 @@
+//+build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Runc is the client to the runc cli
+type Runc struct {
+	//If command is empty, DefaultCommand is used
+	Command       string
+	Root          string
+	Debug         bool
+	Log           string
+	LogFormat     Format
+	PdeathSignal  unix.Signal
+	Setpgid       bool
+	Criu          string
+	SystemdCgroup bool
+	Rootless      *bool // nil stands for "auto"
+}

--- a/runc_windows.go
+++ b/runc_windows.go
@@ -1,0 +1,31 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package runc
+
+// Runc is the client to the runc cli
+type Runc struct {
+	//If command is empty, DefaultCommand is used
+	Command       string
+	Root          string
+	Debug         bool
+	Log           string
+	LogFormat     Format
+	Setpgid       bool
+	Criu          string
+	SystemdCgroup bool
+	Rootless      *bool // nil stands for "auto"
+}


### PR DESCRIPTION
This commit fixes the following build failure.

+ mingw32-make.exe binaries
+ bin/ctr.exe
+ bin/containerd.exe
github.com/containerd/containerd/vendor/github.com/containerd/go-runc
[error]vendor\github.com\containerd\go-runc\runc.go:66:16: undefined: unix.Signal
[error]mingw32-make: *** [Makefile.windows:28: bin/containerd.exe] Error 2
[error]Process completed with exit code 2.

Fixes #65.
Fixes: 421b4ca ("Change the type of PdeathSignal")

Signed-off-by: Hajime Tazaki <thehajime@gmail.com>