### PR TITLE
preserve exit status with wrapped errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
-    - 1.12.x
     - 1.13.x
+    - 1.14.x
+    - 1.15.x
 
 install:
   - go get -t ./...

--- a/console_test.go
+++ b/console_test.go
@@ -34,7 +34,7 @@ func TestTempConsole(t *testing.T) {
 func TestTempConsoleWithXdgRuntimeDir(t *testing.T) {
 	tmpDir := "/tmp/foo"
 	// prevent interferring with other tests
-	defer os.Setenv("XDG_RUNTIME_DIR", "")
+	defer os.Setenv("XDG_RUNTIME_DIR", os.Getenv("XDG_RUNTIME_DIR"))
 	if err := os.Setenv("XDG_RUNTIME_DIR", tmpDir); err != nil {
 		t.Fatal(err)
 	}

--- a/console_test.go
+++ b/console_test.go
@@ -33,6 +33,8 @@ func TestTempConsole(t *testing.T) {
 
 func TestTempConsoleWithXdgRuntimeDir(t *testing.T) {
 	tmpDir := "/tmp/foo"
+	// prevent interferring with other tests
+	defer os.Setenv("XDG_RUNTIME_DIR", "")
 	if err := os.Setenv("XDG_RUNTIME_DIR", tmpDir); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We need to be able capture the exit status from `Exec`, currently the status is discarded.  This PR uses wrapped error to preserve the status via an `ExitError`.  

I have also removed the Go `1.12.x` travis testing, since `errors.As` used in the test was introduced in `1.13`.

cc @tonistiigi 