### PR TITLE
Travis-ci: added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ go:
     - 1.13.x
     - 1.14.x
     - 1.15.x
-
+arch:
+    - AMD64
+    - ppc64le
 install:
   - go get -t ./...
   - go get -u github.com/vbatts/git-validation
   - go get -u github.com/kunalkushwaha/ltag
-
 before_script:
   - pushd ..; git clone https://github.com/containerd/project; popd
 


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.