### PR TITLE
Fix runc update --resources flag usage

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -611,7 +611,7 @@ func (r *Runc) Update(context context.Context, id string, resources *specs.Linux
 	if err := json.NewEncoder(buf).Encode(resources); err != nil {
 		return err
 	}
-	args := []string{"update", "--resources", "-", id}
+	args := []string{"update", "--resources=-", id}
 	cmd := r.command(context, args...)
 	cmd.Stdin = buf
 	return r.runOrError(cmd)


### PR DESCRIPTION
Runc's CLI requires --flag=value arg passing.
Xref: https://github.com/k3s-io/k3s/issues/3104

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>