### PR TITLE
gha: test against go1.16.x and go1.17.x, gofmt with go1.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,18 @@ jobs:
 
   checks:
     name: Project Checks
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 5
+
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
+        os: [ubuntu-18.04]
 
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: ${{ matrix.go-version }}
 
       - name: Set env
         shell: bash
@@ -40,10 +45,14 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         os: [ubuntu-18.04]
 
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
       - uses: actions/checkout@v2
         with:
           path: src/github.com/containerd/go-runc
@@ -58,11 +67,18 @@ jobs:
         with:
           version: v1.29
           working-directory: src/github.com/containerd/go-runc
+          args: --timeout=5m
+          skip-go-installation: true
 
   tests:
     name: Tests
-    runs-on: ubuntu-18.04
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 5
+
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
+        os: [ubuntu-18.04]
 
     steps:
       - uses: actions/checkout@v2
@@ -71,7 +87,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: ${{ matrix.go-version }}
 
       - name: Set env
         shell: bash

--- a/command_other.go
+++ b/command_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/console.go
+++ b/console.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/io_unix.go
+++ b/io_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/io_windows.go
+++ b/io_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
The Linters step is pinned to a single Go version, as go1.16 and go1.17 gofmt won't produce the same result.
