### PR TITLE
Lock to OS thread when Pdeathsig is set

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -18,6 +18,7 @@ package runc
 
 import (
 	"os/exec"
+	"runtime"
 	"syscall"
 	"time"
 )
@@ -32,15 +33,18 @@ type Exit struct {
 	Status    int
 }
 
-// ProcessMonitor is an interface for process monitoring
+// ProcessMonitor is an interface for process monitoring.
 //
 // It allows daemons using go-runc to have a SIGCHLD handler
 // to handle exits without introducing races between the handler
-// and go's exec.Cmd
-// These methods should match the methods exposed by exec.Cmd to provide
-// a consistent experience for the caller
+// and go's exec.Cmd.
+//
+// ProcessMonitor also provides a StartLocked method which is similar to
+// Start, but locks the goroutine used to start the process to an OS thread
+// (for example: when Pdeathsig is set).
 type ProcessMonitor interface {
 	Start(*exec.Cmd) (chan Exit, error)
+	StartLocked(*exec.Cmd) (chan Exit, error)
 	Wait(*exec.Cmd, chan Exit) (int, error)
 }
 
@@ -69,6 +73,43 @@ func (m *defaultMonitor) Start(c *exec.Cmd) (chan Exit, error) {
 		}
 		close(ec)
 	}()
+	return ec, nil
+}
+
+// StartLocked is like Start, but locks the goroutine used to start the process to
+// the OS thread for use-cases where the parent thread matters to the child process
+// (for example: when Pdeathsig is set).
+func (m *defaultMonitor) StartLocked(c *exec.Cmd) (chan Exit, error) {
+	started := make(chan error)
+	ec := make(chan Exit, 1)
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+
+		if err := c.Start(); err != nil {
+			started <- err
+			return
+		}
+		close(started)
+		var status int
+		if err := c.Wait(); err != nil {
+			status = 255
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+					status = ws.ExitStatus()
+				}
+			}
+		}
+		ec <- Exit{
+			Timestamp: time.Now(),
+			Pid:       c.Process.Pid,
+			Status:    status,
+		}
+		close(ec)
+	}()
+	if err := <-started; err != nil {
+		return nil, err
+	}
 	return ec, nil
 }
 


### PR DESCRIPTION
See https://github.com/golang/go/issues/27505 for context. `Pdeathsig`
isn't safe to set without locking to the current OS thread, because
otherwise thread termination will send the signal, which isn't the
desired behavior.

I discovered this while troubleshooting a problem that turned out to be
unrelated, but I think it's necessary for correctness.

cc @coryb