### PR TITLE
Allow DefaultCommand to be customized during build

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -53,6 +53,9 @@ const (
 	JSON Format = "json"
 	// Text represents plain text format
 	Text Format = "text"
+)
+
+var (
 	// DefaultCommand is the default command for Runc
 	DefaultCommand = "runc"
 )


### PR DESCRIPTION
There exist a handful of OCI runtimes, notably crun and youki, which do not ship ContainerD shims but are indirectly supported via containerd-shim-runc-v2 (a.k.a. runtime 'io.containerd.runc.v2') by virtue of being drop-in replacements for runC. These runtimes are more awkward to install and use within the ContainerD ecosystem compared to runtimes which have dedicated shims. It is only possible to e.g. use crun and runc side by side with ContainerD clients which have support compiled in to pass the `BinaryName` option to containerd-shim-runc-v2. For ContainerD clients such as Moby where it would be a security risk to permit users to specify arbitrary BinaryName values, the runtimes must be explicitly registered with it before they can be used. The other option is to install one of the runtimes as `runc` on the system PATH (as is done for ContainerD CI with crun) which works without any client support but precludes more than one such runtime being installed at the same time. In contrast, runtimes which ship their own ContainerD shims, such as gVisor and kata, can be ambiently installed side by side with each other and runC, and can be used by any ContainerD client without any special support or registration. (There are no security concerns with Moby as shim binaries must be on PATH and have names which begin with 'containerd-shim-' to be useable with ContainerD, notwithstanding absolute paths.)

Change DefaultCommand to a variable so that applications which use go-runc can be configured at build time to execute a custom runC-compatible command by default. This allows distribution packagers and others to build e.g. dedicated ContainerD shims for crun and youki without having to maintain forks/patchsets or modify any code.

    go build -ldflags \
      "-X github.com/containerd/go-runc.DefaultCommand=crun" \
      -o containerd-shim-crun-v1 \
      github.com/containerd/containerd/cmd/containerd-shim
