### PR TITLE
Remove references to io/ioutil

### DIFF
--- a/console.go
+++ b/console.go
@@ -21,7 +21,6 @@ package runc
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -54,7 +53,7 @@ func NewConsoleSocket(path string) (*Socket, error) {
 // On Close(), the socket is deleted
 func NewTempConsoleSocket() (*Socket, error) {
 	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
-	dir, err := ioutil.TempDir(runtimeDir, "pty")
+	dir, err := os.MkdirTemp(runtimeDir, "pty")
 	if err != nil {
 		return nil, err
 	}

--- a/runc.go
+++ b/runc.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -261,7 +260,7 @@ func (r *Runc) Exec(context context.Context, id string, spec specs.Process, opts
 	if opts.Started != nil {
 		defer close(opts.Started)
 	}
-	f, err := ioutil.TempFile(os.Getenv("XDG_RUNTIME_DIR"), "runc-process")
+	f, err := os.CreateTemp(os.Getenv("XDG_RUNTIME_DIR"), "runc-process")
 	if err != nil {
 		return err
 	}

--- a/runc_test.go
+++ b/runc_test.go
@@ -19,7 +19,6 @@ package runc
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"sync"
 	"syscall"
@@ -290,7 +289,7 @@ func interrupt(ctx context.Context, t *testing.T, started <-chan int) {
 // dummySleepRunc creates s simple script that just runs `sleep 10` to replace
 // runc for testing process that are longer running.
 func dummySleepRunc() (_ string, err error) {
-	fh, err := ioutil.TempFile("", "*.sh")
+	fh, err := os.CreateTemp("", "*.sh")
 	if err != nil {
 		return "", err
 	}

--- a/utils.go
+++ b/utils.go
@@ -18,7 +18,7 @@ package runc
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -27,7 +27,7 @@ import (
 // ReadPidFile reads the pid file at the provided path and returns
 // the pid or an error if the read and conversion is unsuccessful
 func ReadPidFile(path string) (int, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
io/ioutil package has been marked deprecated in Go 1.16

Signed-off-by: Austin Vazquez <macedonv@amazon.com>