### PR TITLE
Fix Run api with ExtraFiles in CreateOpts

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -327,6 +327,7 @@ func (r *Runc) Run(context context.Context, id, bundle string, opts *CreateOpts)
 	if opts != nil && opts.IO != nil {
 		opts.Set(cmd)
 	}
+	cmd.ExtraFiles = opts.ExtraFiles
 	ec, err := r.startCommand(cmd)
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
Pass along `CreateOpts.ExtraFiles` in the `Run(..)` API.

`Create(..)` API already handles this correctly.

Signed-off-by: Bin Xin <bin.xin@snowflake.com>