### PR TITLE
Fix interval parsing for runc events.

### DIFF
--- a/runc.go
+++ b/runc.go
@@ -423,7 +423,7 @@ func (r *Runc) Stats(context context.Context, id string) (*Stats, error) {
 
 // Events returns an event stream from runc for a container with stats and OOM notifications
 func (r *Runc) Events(context context.Context, id string, interval time.Duration) (chan *Event, error) {
-	cmd := r.command(context, "events", fmt.Sprintf("--interval=%ds", int(interval.Seconds())), id)
+	cmd := r.command(context, "events", fmt.Sprintf("--interval=%s", interval.String()), id)
 	rd, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Issue:
Closes #53 

### Description
Before runc events interval configurations less than 1 second would be truncated to 0. This change enables <1 second interval events channel ticks.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>