### PR TITLE
Add Go 1.22 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         os: [ubuntu-22.04]
 
     steps:
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         os: [ubuntu-22.04]
 
     steps:
@@ -76,7 +76,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.21.x, 1.22.x]
         os: [ubuntu-22.04]
 
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/go-runc
 
-go 1.20
+go 1.21
 
 require (
 	github.com/containerd/console v1.0.3


### PR DESCRIPTION
Issue:
N/A

Description:
This PR adds Go 1.22 to CI and updates minimum Go version to 1.21.