### PR TITLE
exec:support to set custom log path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           path: src/github.com/containerd/go-runc
           fetch-depth: 25
 
-      - uses: containerd/project-checks@v1.1.0
+      - uses: containerd/project-checks@d7751f3c375b8fe4a84c02a068184ee4c1f59bc4 # v1.2.2
         with:
           working-directory: src/github.com/containerd/go-runc
 

--- a/command_linux.go
+++ b/command_linux.go
@@ -25,11 +25,15 @@ import (
 )
 
 func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
+	return r.commandWithCustomLogFile(context, "", args...)
+}
+
+func (r *Runc) commandWithCustomLogFile(context context.Context, logFile string, args ...string) *exec.Cmd {
 	command := r.Command
 	if command == "" {
 		command = DefaultCommand
 	}
-	cmd := exec.CommandContext(context, command, append(r.args(), args...)...)
+	cmd := exec.CommandContext(context, command, append(r.args(logFile), args...)...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: r.Setpgid,
 	}

--- a/command_other.go
+++ b/command_other.go
@@ -25,11 +25,15 @@ import (
 )
 
 func (r *Runc) command(context context.Context, args ...string) *exec.Cmd {
+	return r.commandWithCustomLogFile(context, "", args...)
+}
+
+func (r *Runc) commandWithCustomLogFile(context context.Context, logFile string, args ...string) *exec.Cmd {
 	command := r.Command
 	if command == "" {
 		command = DefaultCommand
 	}
-	cmd := exec.CommandContext(context, command, append(r.args(), args...)...)
+	cmd := exec.CommandContext(context, command, append(r.args(logFile), args...)...)
 	cmd.Env = os.Environ()
 	return cmd
 }

--- a/runc.go
+++ b/runc.go
@@ -228,6 +228,7 @@ func (r *Runc) Start(context context.Context, id string) error {
 // ExecOpts holds optional settings when starting an exec process with runc
 type ExecOpts struct {
 	IO
+	LogFile       string
 	PidFile       string
 	ConsoleSocket ConsoleSocket
 	Detach        bool
@@ -280,7 +281,7 @@ func (r *Runc) Exec(context context.Context, id string, spec specs.Process, opts
 		return err
 	}
 	args = append(args, oargs...)
-	cmd := r.command(context, append(args, id)...)
+	cmd := r.commandWithCustomLogFile(context, opts.LogFile, append(args, id)...)
 	if opts.IO != nil {
 		opts.Set(cmd)
 	}
@@ -765,7 +766,7 @@ func (r *Runc) Features(context context.Context) (*features.Features, error) {
 	return &feat, nil
 }
 
-func (r *Runc) args() (out []string) {
+func (r *Runc) args(logFile string) (out []string) {
 	if r.Root != "" {
 		out = append(out, "--root", r.Root)
 	}
@@ -773,7 +774,12 @@ func (r *Runc) args() (out []string) {
 		out = append(out, "--debug")
 	}
 	if r.Log != "" {
-		out = append(out, "--log", r.Log)
+		if logFile == "" {
+			out = append(out, "--log", r.Log)
+		}
+	}
+	if logFile != "" {
+		out = append(out, "--log", logFile)
 	}
 	if r.LogFormat != none {
 		out = append(out, "--log-format", string(r.LogFormat))

--- a/runc_test.go
+++ b/runc_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -333,6 +334,33 @@ func TestCreateArgs(t *testing.T) {
 	}
 	if a := args[0]; a != "--other" {
 		t.Fatalf("arg should be --other but got %q", a)
+	}
+}
+
+func TestExecWithLogFile(t *testing.T) {
+	ctx := context.Background()
+	o := &Runc{}
+	cmd := o.commandWithCustomLogFile(ctx, "/tmp/exec.log", "version")
+	if got := strings.Join(cmd.Args[1:], " "); got != "--log /tmp/exec.log version" {
+		t.Fatalf("expected args %q, got %q", "--log /tmp/exec.log version", got)
+	}
+
+	o = &Runc{Log: "/tmp/runc.log"}
+	cmd = o.commandWithCustomLogFile(ctx, "/tmp/exec.log", "version")
+	if got := strings.Join(cmd.Args[1:], " "); got != "--log /tmp/exec.log version" {
+		t.Fatalf("expected args %q, got %q", "--log /tmp/exec.log version", got)
+	}
+
+	o = &Runc{Log: "/tmp/runc.log"}
+	cmd = o.commandWithCustomLogFile(ctx, "", "version")
+	if got := strings.Join(cmd.Args[1:], " "); got != "--log /tmp/runc.log version" {
+		t.Fatalf("expected args %q, got %q", "--log /tmp/runc.log version", got)
+	}
+
+	o = &Runc{}
+	cmd = o.commandWithCustomLogFile(ctx, "", "version")
+	if got := strings.Join(cmd.Args[1:], " "); got != "version" {
+		t.Fatalf("expected args %q, got %q", "version", got)
 	}
 }
 


### PR DESCRIPTION
I create  a pr https://github.com/containerd/containerd/pull/11862 to address  https://github.com/containerd/containerd/issues/8972
I want to specify runc log to custom path when exec . 