### PR TITLE
Wire WorkDir into runc command invocation

### DIFF
--- a/command_linux.go
+++ b/command_linux.go
@@ -38,6 +38,7 @@ func (r *Runc) commandWithCustomLogFile(context context.Context, logFile string,
 		Setpgid: r.Setpgid,
 	}
 	cmd.Env = filterEnv(os.Environ(), "NOTIFY_SOCKET") // NOTIFY_SOCKET introduces a special behavior in runc but should only be set if invoked from systemd
+	cmd.Dir = r.WorkDir
 	if r.PdeathSignal != 0 {
 		cmd.SysProcAttr.Pdeathsig = r.PdeathSignal
 	}

--- a/command_other.go
+++ b/command_other.go
@@ -35,5 +35,6 @@ func (r *Runc) commandWithCustomLogFile(context context.Context, logFile string,
 	}
 	cmd := exec.CommandContext(context, command, append(r.args(logFile), args...)...)
 	cmd.Env = os.Environ()
+	cmd.Dir = r.WorkDir
 	return cmd
 }

--- a/runc.go
+++ b/runc.go
@@ -62,7 +62,10 @@ var DefaultCommand = "runc"
 type Runc struct {
 	// Command overrides the name of the runc binary. If empty, DefaultCommand
 	// is used.
-	Command   string
+	Command string
+	// WorkDir sets the working directory of the runc process. If empty, the
+	// working directory of the calling process is used.
+	WorkDir   string
 	Root      string
 	Debug     bool
 	Log       string

--- a/runc_test.go
+++ b/runc_test.go
@@ -315,6 +315,27 @@ func dummySleepRunc() (_ string, err error) {
 	return fh.Name(), nil
 }
 
+func TestCommandWorkDir(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("WorkDir is unset", func(t *testing.T) {
+		r := &Runc{}
+		cmd := r.command(ctx, "list")
+		if cmd.Dir != "" {
+			t.Fatalf("expected empty cmd.Dir, got %q", cmd.Dir)
+		}
+	})
+
+	t.Run("WorkDir is set", func(t *testing.T) {
+		dir := t.TempDir()
+		r := &Runc{WorkDir: dir}
+		cmd := r.command(ctx, "list")
+		if cmd.Dir != dir {
+			t.Fatalf("expected cmd.Dir %q, got %q", dir, cmd.Dir)
+		}
+	})
+}
+
 func TestCreateArgs(t *testing.T) {
 	o := &CreateOpts{}
 	args, err := o.args()


### PR DESCRIPTION
I'm using go-runc in github.com/cpuguy83/containerd-shim-systemd-v1 and to make some of the containerd integration tests pass on the shim I need runc to execute in the bundle root, but go-runc didn't really provide a good way to do that, which means either dealing with re-exec or some unshare/chdir logic.